### PR TITLE
ci: stop the simulation heartbeat from crying wolf

### DIFF
--- a/.github/workflows/testSimulationsWorking.yaml
+++ b/.github/workflows/testSimulationsWorking.yaml
@@ -1,8 +1,21 @@
 name: Test simulation functionality
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    # GitHub delivers only a fraction of scheduled triggers on free-tier public
+    # repos. Measured against the previous '*/5' cron (288/day nominal) this
+    # workflow actually ran 25-100 times/day (9-34%) over Jun-Aug 2026, with
+    # observed gaps up to 4 hours. A tighter interval is fiction, and every
+    # trigger submits a real simulation run to production, so ask for less.
+    - cron: '*/15 * * * *'
   workflow_dispatch:
+
+# Each run submits a real simulation to production and then polls it, so a slow
+# queue can stretch a run well past the schedule interval. Serialize rather than
+# piling probes on top of each other.
+concurrency:
+  group: test-simulations-working
+  cancel-in-progress: false
+
 env:
   NX_SKIP_NX_CACHE: ${{ vars.NX_SKIP_NX_CACHE_VALUE }}
 
@@ -10,6 +23,7 @@ jobs:
   testSimulations:
     name: Run example simulations
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,11 +43,35 @@ jobs:
             --runbiosimulations-deployment org \
             --biosimulators-deployment org \
             --test true \
+            --timeout 3600 \
             --example "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; CVODE; tellurium)"
-  sendHeartbeat:
-    name: Send Success Hearbeat
+
+  reportHeartbeat:
+    name: Report heartbeat
     needs: testSimulations
     runs-on: ubuntu-latest
+    # Report only a real pass or a real fail. A run cancelled by the concurrency
+    # group never exercised the API, so it must not be reported either way.
+    if: ${{ always() && contains(fromJSON('["success", "failure"]'), needs.testSimulations.result) }}
     steps:
-        - if: ${{ success() }}
-          run: curl ${{secrets.SIMULATIONS_HEARTBEAT}}
+      - name: Report result to uptime monitor
+        env:
+          HEARTBEAT_URL: ${{ secrets.SIMULATIONS_HEARTBEAT }}
+          RESULT: ${{ needs.testSimulations.result }}
+        run: |
+          if [ -z "$HEARTBEAT_URL" ]; then
+            echo "::error::SIMULATIONS_HEARTBEAT secret is not set"
+            exit 1
+          fi
+
+          # Posting /fail makes a broken service page immediately, instead of
+          # waiting for the monitor to notice a missing heartbeat -- which it
+          # cannot distinguish from GitHub having skipped the schedule.
+          if [ "$RESULT" = "success" ]; then
+            url="$HEARTBEAT_URL"
+          else
+            url="$HEARTBEAT_URL/fail"
+          fi
+
+          echo "Reporting '$RESULT' to the uptime monitor"
+          curl -fsS --max-time 30 --retry 3 --retry-all-errors -o /dev/null "$url"


### PR DESCRIPTION
## The problem

The BetterStack **"Simulation Service"** heartbeat monitor reports chronic downtime — 89.3% availability and **759 incidents** over the last 365 days, ~2 per day for a year.

The service is fine. The monitor is measuring **GitHub Actions' cron scheduler**.

At the time of investigation (2026-08-28) the monitor had been "down 2 h 51 m" while the API was healthy and every recent run of this workflow had concluded `success`:

```
https://api.biosimulations.org/health            200  0.63s
https://api.biosimulations.org/                  200  0.22s
https://api.biosimulators.org/simulators/latest  200  1.53s
```

The heartbeat simply was never *sent*, because GitHub never triggered the workflow.

### GitHub never honoured the `*/5` cron

This is a public repo on free-tier Actions, where `schedule` is explicitly best-effort. Measured delivery against the nominal 288 runs/day:

| Period | Runs | Runs/day | % of nominal |
|---|---|---|---|
| 2026-06-01 → 06-30 | 748 | 25 | 8.7% |
| 2026-07-01 → 07-15 | 503 | 33 | 12% |
| 2026-07-16 → 07-28 | 486 | 37 | 13% |
| 2026-07-29 → 08-14 | 779 | 46 | 16% |
| 2026-08-15 → 08-28 | 1053 | 75 | 26% |
| **2026-08-27** | **9** | **9** | **3%** |

Gap statistics over the last ~200 runs: median 17.9 min, **max 246 min**, and **17 of 199 gaps exceeded 60 minutes** — matching the monitor's reported "17 incidents in the last 7 days" almost exactly. Every one of those gaps was bracketed by *successful* runs.

Three details confirm this is scheduler drift rather than anything wrong on our side:

- Queue delay (`created_at` → `started_at`) is **0 s** on every run. Runs that fire start instantly; the loss is GitHub declining to *create* them.
- `created_at` minute-of-hour is spread uniformly across `mod 5 = {0,1,2,3,4}` (39/32/35/41/53). A real `*/5` cron lands on `:00/:05/:10` every time.
- Typical job duration is ~60 s, so there is no self-contention.

A 1-hour heartbeat expectation is simply unsatisfiable by a GitHub Actions cron.

## What this PR changes

**Report failures explicitly.** `sendHeartbeat` only ever fired `if: success()`, so "the service broke" and "GitHub skipped the schedule" produced the identical signal: silence. The job now posts to `<heartbeat-url>/fail` on failure, so a genuine outage pages immediately and a *missing* heartbeat no longer has to carry that meaning.

**Ask for a cadence GitHub might actually deliver** — `*/15` instead of `*/5`. The tighter interval was never honoured, and since every trigger submits a real Repressilator simulation to production, this also cuts synthetic prod load roughly 4×.

**Serialize with a `concurrency` group,** and skip reporting for runs the group cancels — those never touched the API, so they must not report success *or* failure.

**Raise the polling timeout from the 999 s default to 3600 s.** `--test true` polls until `SUCCEEDED`, bounded by `--timeout`, which the workflow never overrode. A run on 2026-08-26 legitimately took **2772 s** and passed; with `/fail` reporting now in place, a 999 s bound would turn "the queue is busy" into a page. At 3600 s a timeout genuinely means the queue is stuck.

**Harden the report step** — `curl -fsS --max-time 30 --retry 3`, plus a loud error if `SIMULATIONS_HEARTBEAT` is unset (today a missing secret would `curl` an empty URL and pass silently).

## Required change outside this repo

⚠️ **The BetterStack monitor's period must be raised from 1 hour to ≥ 6 hours.** Even after this PR, GitHub's delivery rate makes a 1-hour expectation unmeetable — the observed p100 gap is ~4 h and quiet days deliver only 5 runs. With `/fail` reporting in place the heartbeat's job becomes "did CI run at all", which warrants a generous grace period; real breakage now arrives via `/fail` instead.

## Follow-ups not included here

These need changes to `tools/submit-example-simulation-runs` rather than the workflow, so they are left for a separate PR:

- **Submit failures report an empty error.** The script shells out to `curl` with no `--fail`, no `--max-time` and no retry, never checks the return code or HTTP status, then `json.loads()` the stdout. The 11 consecutive failures on 2026-08-24 all surfaced as `RuntimeError: Simulation could not be run on https://api.biosimulations.org/runs:` with a blank message. A DNS blip, a TLS reset, a 502 from the ingress and a real outage are indistinguishable.
- **Timeout is not distinguished from failure.** `monitor_runs()` returns `passed=False` for both, so the caller cannot tell "slow queue" from "broken".
- **Bug in `monitor_runs()`:** on `raise_for_status()` failure it moves the run to `failed_runs` and then falls through to `sim = response.json()` on that same failed response, which will itself raise.

## Longer term

The right fix is to move this probe off the GitHub Actions scheduler entirely — an in-cluster `CronJob` gives an exact cadence and can support a tight heartbeat honestly. The two signals also want splitting: a cheap high-frequency HTTP monitor on `/health` for real availability, and a low-frequency end-to-end simulation probe like this one. Full write-up, measurements and re-run recipe live in `docs/biosimulations-legacy-services.md` in the `biosimulations/platform` repo.

## Verification

`actionlint` clean; YAML and the `run` block's shell syntax both parse. The new schedule takes effect only once merged to `dev`, since scheduled workflows run from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128cFk66ZCDDUag9GBfD4LP
